### PR TITLE
Update Erlang dependency to address CVE-2025-32433

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.2.1
+erlang 27.3.3
 elixir 1.18.2-otp-27


### PR DESCRIPTION
This is not strictly necessary since the book does not make use of the Erlang `:ssh` client, but there is no harm in upgrading this dependency.